### PR TITLE
Add get_exports to NotStartedModuleRef

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -700,8 +700,8 @@ impl<'a> NotStartedModuleRef<'a> {
 		self.instance
 	}
 
-	pub fn get_exports(&self) -> HashMap<String, ExternVal> {
-		self.instance.exports.borrow().clone()
+	pub fn get_exports(&self) -> &RefCell<HashMap<String, ExternVal>> {
+		&self.instance.exports
 	}
 }
 


### PR DESCRIPTION
Required to go calculate sighashes of exported functions.

Reference: https://github.com/oasislabs/runtime-ethereum/issues/665