### PR TITLE
Enable wasmer to import functions with args of type P

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["wasm", "webassembly", "bytecode", "interpreter"]
 exclude = [ "/res/*", "/tests/*", "/fuzz/*", "/benches/*" ]
 
 [dependencies]
+wasmer-runtime-core = "0.4.2"
 wasmi-validation = { version = "0.1", path = "validation", default-features = false }
 parity-wasm = { version = "0.31", default-features = false }
 hashbrown = { version = "0.1.8", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ extern crate memory_units as memory_units_crate;
 extern crate parity_wasm;
 
 extern crate wasmi_validation as validation;
+extern crate wasmer_runtime_core;
 
 #[allow(unused_imports)]
 use alloc::prelude::v1::*;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -11,6 +11,8 @@ use memory_units::{Bytes, Pages, RoundUpTo};
 use parity_wasm::elements::ResizableLimits;
 use Error;
 
+use wasmer_runtime_core::types::{WasmExternType};
+
 /// Size of a page of [linear memory][`MemoryInstance`] - 64KiB.
 ///
 /// The size of a memory is always a integer multiple of a page size.
@@ -112,6 +114,20 @@ impl<T> From<u32> for P<T> {
         Self {
             offset,
             ty: std::marker::PhantomData
+        }
+    }
+}
+
+unsafe impl<T: Copy> WasmExternType for P<T> {
+    type Native = i32;
+
+    fn to_native(self) -> Self::Native {
+        self.offset as i32
+    }
+    fn from_native(n: Self::Native) -> Self {
+        Self {
+            offset: n as u32,
+            ty: std::marker::PhantomData,
         }
     }
 }


### PR DESCRIPTION
We want to use the same types (wasmi::P) across wasmi and wasmer within the runtime.
As far as I know, implementing this trait is the only way to get wasmi::P to work with wasmer, which is used in our WASI implementation. 

Sorry if the extra dependency is undesirable, but I think this is ideal as it saves a lot of boilerplate. Unless there is an easier way to do this?
